### PR TITLE
Add rtoken guardian address

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -327,6 +327,9 @@ type RToken @entity {
   " long freezers (this role is revoked after action) "
   longFreezers: [String!]!
 
+  " Guardians "
+  guardians: [String!]!
+
   ##### Quantitative Data ####
   " Collaterization of this rToken %"
   backing: BigInt!

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -78,6 +78,7 @@ export namespace Roles {
   export const PAUSER = "PAUSER";
   export const SHORT_FREEZER = "SHORT_FREEZER";
   export const LONG_FREEZER = "LONG_FREEZER";
+  export const GUARDIAN = "CANCELLER_ROLE";
 }
 
 export namespace ContractName {

--- a/src/mappings/rToken.ts
+++ b/src/mappings/rToken.ts
@@ -111,6 +111,7 @@ export function handleCreateToken(event: RTokenCreated): void {
   rToken.freezers = [];
   rToken.pausers = [];
   rToken.longFreezers = [];
+  rToken.guardians = [];
   rToken.cumulativeUniqueUsers = INT_ONE;
   rToken.rewardTokenSupply = BIGINT_ZERO;
   rToken.rsrPriceUSD = getRSRPrice();
@@ -371,6 +372,8 @@ function roleToProp(role: string): string {
     return "pausers";
   } else if (role == Roles.SHORT_FREEZER) {
     return "freezers";
+  } else if (role == Roles.GUARDIAN) {
+    return "guardians";
   }
 
   return "longFreezers";


### PR DESCRIPTION
This adds the guardian role (indexed as `CANCELLER_ROLE` on the smart contract) to the RToken entity